### PR TITLE
docs: add user manual + full technical documentation

### DIFF
--- a/docs/ARQUITECTURA.md
+++ b/docs/ARQUITECTURA.md
@@ -1,0 +1,239 @@
+# Arquitectura
+
+Documentación técnica para developers. Si eres staff, ve a [MANUAL_USUARIO.md](./MANUAL_USUARIO.md).
+
+---
+
+## Stack
+
+- **Framework**: Next.js 16 (App Router).
+- **Runtime**: Node 20.x (ver `"engines"` en `package.json`).
+- **UI**: React 18.3, TypeScript 5.9.
+- **Estilos**: Tailwind CSS 3.4 + `tailwindcss-animate`. Paleta en `tailwind.config.ts`.
+- **Componentes accesibles**: Radix UI (dialog, dropdown, accordion, navigation menu).
+- **Animaciones**: Framer Motion.
+- **Data fetching**: TanStack React Query 5 (paginación infinita en listados de programas).
+- **Formularios / toasts**: react-toastify.
+- **Iconos**: lucide-react + react-icons.
+- **Imágenes**: next/image con dominios remotos permitidos (ver `next.config.mjs`).
+- **Imágenes (optimización)**: sharp.
+- **Hosting**: Vercel (inferido — no hay `vercel.json`, Vercel usa defaults de Next.js).
+
+---
+
+## Estructura de carpetas
+
+```
+the-gate-main-page/
+├── app/                         Rutas del App Router (Next.js 13+)
+│   ├── layout.tsx               Root layout, metadata, fonts
+│   ├── page.tsx                 Home (/)
+│   ├── provider.tsx             React Query provider + Toastify
+│   ├── template.tsx             Template re-render entre rutas
+│   ├── globals.css              Tailwind + animaciones custom
+│   ├── about/                   /about
+│   ├── alianzas/                /alianzas
+│   ├── aviso-de-privacidad/     /aviso-de-privacidad
+│   ├── contact/                 /contact
+│   ├── destinos/                /destinos
+│   ├── estudiante/              /estudiante (tabla de servicios)
+│   ├── instituciones/           /instituciones
+│   ├── news/                    /news (placeholder)
+│   ├── programs/
+│   │   ├── page.tsx             /programs (hub)
+│   │   ├── masters/             /programs/masters (desde Google Sheet)
+│   │   ├── bachelors/           /programs/bachelors (desde CSV)
+│   │   └── camps/               /programs/camps
+│   ├── services/                /services
+│   └── api/                     API routes
+│       └── programs/
+│           ├── masters/route.ts   Fetch Apps Script + fallback CSV
+│           └── csv/route.ts       Fetch licenciaturas CSV
+│
+├── src/
+│   ├── components/              Componentes React organizados por feature
+│   │   ├── Hero/                Hero reutilizable (home + páginas internas)
+│   │   ├── Navbar/              Navbar con dropdowns + mobile sheet
+│   │   ├── Footer/              Footer + ICEF badge + carrusel aliados
+│   │   ├── Homepage/            Secciones exclusivas del home
+│   │   ├── cale/                Componentes de programas (ProgramPage, Cards)
+│   │   ├── estudiantes/         ServiceCard, SummaryCard
+│   │   ├── instituciones/       InfoCard
+│   │   ├── ContactUs/           Formulario de contacto
+│   │   └── ...
+│   ├── data/                    Datos hardcodeados (JSON / TS)
+│   │   ├── destinations.ts      Países del sitio
+│   │   ├── constantes.ts        Logos de aliados, endpoints, categorías
+│   │   ├── summerCampsData.ts   Camps por edad
+│   │   ├── categorias_texto.json Textos de categorías de programas
+│   │   └── ...
+│   ├── lib/                     Parsers y utilidades
+│   │   ├── parseLicenciaturas.ts  Parser de CSV
+│   │   └── Listado_Masters.csv    Fallback cuando Apps Script falla
+│   ├── services/                Clientes HTTP
+│   │   └── studentsRecords.service.ts   POST del formulario
+│   ├── config/
+│   │   └── env.ts               Endpoints hardcoded (AWS Lambda)
+│   └── builder-registry.ts      Integración Builder.io (opcional)
+│
+├── public/                      Assets estáticos (favicons, imágenes locales)
+├── docs/                        ← Estás aquí
+├── tailwind.config.ts           Paleta, fonts, animaciones, plugins
+├── next.config.mjs              Dominios de imágenes permitidos
+├── tsconfig.json                Paths (@app, @src, etc.)
+└── package.json                 Scripts + deps
+```
+
+### Aliases de import (`tsconfig.json`)
+
+- `@app/*` → `app/*`
+- `@src/*` → `src/*`
+
+Úsalos siempre en vez de rutas relativas profundas (`../../../`).
+
+---
+
+## Setup local
+
+### Requisitos
+
+- **Node 20.x** (definido en `engines`). Usa `nvm use 20` o instala con `fnm`.
+- **npm** (el repo usa `package-lock.json` implícito; puedes usar `bun` si prefieres, pero verifica que `bun install` no cambie el lockfile).
+
+### Comandos
+
+```bash
+# Clonar
+git clone https://github.com/TheGateEducation/the-gate-main-page.git
+cd the-gate-main-page
+
+# Instalar deps
+npm install
+
+# Dev server con Turbopack
+npm run dev            # http://localhost:3000
+
+# Build de producción
+npm run build
+
+# Correr el build
+npm run start
+
+# Linter
+npm run lint
+```
+
+### Variables de entorno
+
+El repo **no usa `.env.local`** por defecto, excepto para una integración opcional:
+
+| Variable | Dónde se usa | Requerido | Descripción |
+|----------|--------------|-----------|-------------|
+| `NEXT_PUBLIC_BUILDER_API_KEY` | `src/builder-registry.ts` | No | Solo si se activa Builder.io para edición visual. Actualmente no está en uso en producción. |
+
+Los **endpoints externos** (AWS Lambda, Apps Script, S3, ICEF) están **hardcoded** en el código en vez de env vars. Esto es frágil — si se rota alguna URL hay que cambiar código. Candidato para refactor (ver TUTORIALES.md).
+
+Referencias hardcoded:
+
+- **AWS Lambda (formulario de contacto)** → `src/config/env.ts`:
+  ```ts
+  THEGATE_EDUCATION_API_DOMAIN = "https://mbhyn4didf.execute-api.us-east-2.amazonaws.com/stage"
+  ```
+- **Google Apps Script (maestrías)** → `app/api/programs/masters/route.ts`:
+  ```ts
+  const APPS_SCRIPT_URL = "https://script.google.com/macros/s/AKfycbx-zfQQASyz.../exec"
+  ```
+- **S3 bucket de imágenes** → URLs directas en `src/data/constantes.ts` y otros archivos.
+
+---
+
+## Deploy
+
+El sitio se despliega en **Vercel** automáticamente desde GitHub:
+
+- **Producción**: push / merge a `development` → deploy automático al dominio de prod.
+- **Preview**: cada PR genera un deploy de preview en un subdominio temporal (`*.vercel.app`). Vercel comenta el link en el PR.
+
+### Configuración Vercel
+
+- **Framework preset**: Next.js (auto-detectado).
+- **Build command**: `npm run build` (default).
+- **Install command**: `npm install` (default).
+- **Output directory**: `.next` (default).
+- **Node version**: 20.x (ver `engines` en `package.json`).
+
+No hay `vercel.json` — todo usa defaults.
+
+### Dominios de imágenes permitidos
+
+`next.config.mjs` define qué hosts puede usar `<Image>`:
+
+```js
+remotePatterns: [
+  { hostname: "images-bucket-landing-page.s3.us-east-2.amazonaws.com" },
+  { hostname: "images.pexels.com" },
+  { hostname: "www-cdn.icef.com" },
+]
+```
+
+Si agregas imágenes de un nuevo CDN, añádelo aquí o `<Image>` dará error de dominio no permitido.
+
+---
+
+## Ramas y flujo de trabajo
+
+- Rama default: **`development`**. El remoto `origin/HEAD` apunta aquí.
+- **No hay `main` remoto** — todo se mergea a `development`.
+- Flujo: `development` → rama feature (`feat/...`, `fix/...`, `docs/...`) → PR → review → merge a `development`.
+- **No hacer force-push a `development`** salvo emergencias (limpieza de commits con autores no deseados, etc.) — y siempre con `--force-with-lease`.
+
+### Convenciones de commits
+
+Basado en los commits existentes (`git log`):
+
+- `feat: ...` — feature nueva.
+- `fix: ...` — arreglo de bug o de visual.
+- `docs: ...` — cambios en documentación.
+- `refactor: ...` — cambios internos sin afectar comportamiento.
+- `chore: ...` — dependencias, config, CI.
+
+Todos en español o inglés, el repo no es estricto pero la mayoría están en inglés.
+
+---
+
+## Paleta de colores
+
+Definida en `tailwind.config.ts`:
+
+| Token | Hex | Uso típico |
+|-------|-----|-----------|
+| `customPurple` | `#5F338B` | Color primario de marca, títulos, CTAs secundarios |
+| `customOrange` | `#EDA74C` | CTA principal, accentos |
+| `customOrangeHover` | `#d99530` | Hover del CTA naranja |
+| `customMint` | `#699984` | Acento, summer camps |
+| `whiteNotWhite` | `#FCFBF8` | Background suave |
+
+Algunos componentes todavía usan los hex directos (`bg-[#5F338B]`). Cuando modifiques uno, **prefiere el token** — así un cambio de paleta solo toca `tailwind.config.ts`.
+
+### Fuentes
+
+- **Poppins**: primaria (cuerpo y títulos).
+- **Montserrat**: secundaria, en algunos titulares.
+
+Cargadas vía `next/font/google` en `app/layout.tsx`.
+
+---
+
+## Integraciones externas
+
+| Servicio | Qué hace | Archivo(s) clave |
+|----------|----------|------------------|
+| **Google Apps Script** | Fuente del catálogo de maestrías | `app/api/programs/masters/route.ts` |
+| **AWS Lambda (stage)** | Recibe envíos del formulario de `/contact` | `src/services/studentsRecords.service.ts`, `src/config/env.ts` |
+| **AWS S3** | Almacena imágenes y logos | URLs en `src/data/constantes.ts`, `app/layout.tsx` |
+| **ICEF** | Badge de certificación en el footer | `src/components/Footer/Footer.tsx` |
+| **Calendly** | Booking de asesorías (`calendly.com/thegateeducation/30min`) | `src/components/Navbar/Navbar.tsx`, `src/components/Hero/Hero.tsx`, varias páginas |
+| **Pexels** | Algunas imágenes stock | URLs en código |
+| **Builder.io** | CMS visual (opcional, no activo en prod) | `src/builder-registry.ts` |
+
+Ver [DATA.md](./DATA.md) para el detalle.

--- a/docs/COMPONENTES.md
+++ b/docs/COMPONENTES.md
@@ -1,0 +1,225 @@
+# Componentes reutilizables
+
+Los componentes que se usan en varias páginas. Componentes específicos de una sola ruta no se listan aquí — revísalos en su archivo correspondiente.
+
+---
+
+## `<Hero>` — `src/components/Hero/Hero.tsx`
+
+Hero flexible, estándar de toda la landing. Usado en **home, destinos, masters, bachelors, camps, services, instituciones, alianzas, programs, news**.
+
+### Props
+
+```ts
+{
+  title: string;                              // requerido
+  titleType?: "gradient" | "white";           // default "gradient"
+  subtitle?: string;
+  subtitleColor?: string;                     // "white" | "black"
+  imageUrl?: string;                          // requerido si backgroundType === "image"
+  backgroundType?: "image" | "gradient" | "none";  // default "none"
+  className?: string;
+  showCTA?: boolean;                          // muestra CTAs "Explorar Programas" + "Agenda Asesoría"
+  fullHeight?: boolean;                       // min-h-screen (para home)
+}
+```
+
+### Reglas de render
+
+- Si `fullHeight && backgroundType === "none"` → **modo home**: gradiente morado con polaroids flotantes de países + ola inferior + decoraciones (círculos, mapa, avión, puntos).
+- Si `backgroundType === "gradient"` → gradiente naranja→rosa→morado (`#EDA74C → #D25C7A → #9747FF`).
+- Si `backgroundType === "image"` → imagen de fondo con overlay negro 40% opacity.
+- Si `backgroundType === "none"` → fondo blanco.
+
+### Título auto-blanco
+
+Si el fondo es colorido (`isHome || backgroundType === "gradient" || backgroundType === "image"`), el título fuerza `text-white` aunque pases `titleType="gradient"`. Esto evita títulos invisibles.
+
+### Ejemplos
+
+```tsx
+// Home
+<Hero
+  title="Donde hay una puerta abierta, hay un mundo por descubrir"
+  subtitle="Te acompañamos..."
+  showCTA
+  fullHeight
+/>
+
+// Página con imagen de fondo
+<Hero
+  title="Maestrías"
+  backgroundType="image"
+  imageUrl="https://..."
+/>
+
+// Página con gradiente
+<Hero
+  title="Camps"
+  backgroundType="gradient"
+/>
+```
+
+---
+
+## `<Navbar>` — `src/components/Navbar/Navbar.tsx`
+
+Navbar principal, fijo arriba en todas las páginas. Logo morado con pill blanco, links, CTA "Agenda Ahora".
+
+- **Menú desktop**: links en pill blanco centrado (Programas, Destinos, Servicios, Alianzas, Contacto).
+- **Menú móvil**: Radix dialog (hamburger abre un sheet).
+- **Logo**: `<Logo>` en `src/components/Navbar/components/Logo.tsx` (imagen PNG desde S3).
+- **CTA "Agenda Ahora"**: link a Calendly.
+
+Navbar se auto-incluye desde `app/layout.tsx` → `app/provider.tsx`. No hace falta incluirlo en cada page.
+
+---
+
+## `<Footer>` — `src/components/Footer/Footer.tsx`
+
+Footer global, incluido desde el layout. Contiene:
+
+- Links de navegación secundaria.
+- Información de contacto (oficinas).
+- Redes sociales.
+- **Badge de ICEF** — `<div id="ias_badge">` con script inyectado vía `useEffect` y cache-busted (ver [DATA.md § ICEF badge](./DATA.md#icef-badge)).
+- Carrusel de aliados (`<Carousel>`).
+
+### Client component porque:
+
+- Necesita `useEffect` para re-inicializar el ICEF badge en navegación SPA.
+
+---
+
+## `<Carousel>` — `src/components/Footer/Carousel.tsx`
+
+Carrusel infinito horizontal con los logos de aliados. Renderizado justo arriba del footer.
+
+- **Fuente de logos**: `src/data/constantes.ts` → export `logos`.
+- **Animación**: CSS `animate-infinite-scroll` (definida en `tailwind.config.ts`).
+- **Mask**: `[mask-image: linear-gradient(...)]` para fade en los bordes.
+- **Fondo**: blanco (antes era `#EDA74C`, cambió para que no se lea como franja).
+
+---
+
+## `<ProgramPage>` — `src/components/cale/ProgramPage.tsx`
+
+Container principal para listados de programas (maestrías, licenciaturas, camps). Maneja:
+
+- Fetch paginado vía React Query (`useInfiniteQuery`).
+- Estado de filtros (país, área, edad según caso).
+- Render de `<ProgramCardsPorArea>` o `<ProgramCardsPorEdades>` según el modo.
+- Prop `skipHero` si la página ya tiene su propio Hero arriba.
+
+Props principales: `fetchUrl`, `filters`, `cardComponent`, `skipHero`.
+
+---
+
+## `<ProgramCardsPorArea>` — `src/components/cale/ProgramCardsPorArea.tsx`
+
+Renderiza una lista de programas agrupados por área de estudio. Cada card muestra institución, programa, ubicación, fechas, duración, costo, link.
+
+Uso: cuando el filtro activo NO es por edad (maestrías, licenciaturas).
+
+---
+
+## `<ProgramCardsPorEdades>` — `src/components/cale/ProgramCardsPorEdades.tsx`
+
+Similar a la versión por área, pero agrupa por rango de edad. Usada en camps.
+
+Formato de cada card: nombre, edades, fechas, duración, ciudad, tipo de alojamiento, costo en MXN, proveedor, notas.
+
+---
+
+## `<SummerCampCards>` — `src/components/cale/SummerCampCards.tsx`
+
+Grid top-level para `/programs/camps` con filtrado por edad. Consume `src/data/summerCampsData.ts`.
+
+---
+
+## `<ServiceCard>` — `src/components/estudiantes/ServiceCard.tsx`
+
+Card usada en `/estudiante` para cada servicio. Tiene:
+
+- Título, descripción, precio.
+- Border color dinámico (prop `borderColor`).
+- Checkbox para seleccionarlo / deseleccionarlo (toggle).
+- `isSelected` controla estado visual; `onToggle(id)` se llama al click.
+
+---
+
+## `<SummaryCard>` — `src/components/estudiantes/SummaryCard.tsx`
+
+Card sticky que muestra el total acumulado de los servicios seleccionados en `/estudiante`.
+
+Props: `selectedServices: Service[]`.
+
+---
+
+## `<InfoCard>` — `src/components/instituciones/InfoCard.tsx`
+
+Card simple para listar servicios a instituciones en `/instituciones`. Props: `title`, `borderColor`.
+
+---
+
+## `<CardCTA>` — `src/components/Services/CardCTA.tsx`
+
+Card con CTA para la página `/services`. Gradiente + icono + botón.
+
+---
+
+## `<Destinations>` — `src/components/Homepage/Destinations/Destinations.tsx`
+
+Grid de países en el home. Consume `src/data/destinations.ts`. Solo en el home.
+
+---
+
+## `<Programs>` — `src/components/Homepage/Programs/Programs.tsx`
+
+Grid de categorías en el home. Solo en el home.
+
+---
+
+## `<Stadistics>` + `<Questions>` — `src/components/Homepage/Stadistics/`
+
+Sección con los números (15+ países, 300+ instituciones, 98% aceptación) + sección de preguntas frecuentes. Solo en el home.
+
+La animación de números la hace un componente custom (se quitó `react-countup` por un crash SSR — ver commit `9ff1574`).
+
+---
+
+## `<MeetTeam>` — `src/components/Homepage/MeetTeam/MeetTeam.tsx`
+
+Sección del equipo en el home con Paulina y Alejandra. Datos **hardcoded en el propio archivo** — ver [DATA.md § Equipo](./DATA.md#equipo-ts-hardcoded-en-componente).
+
+---
+
+## `<MissionVision>` — `src/components/Homepage/MissionVision/missionvision.tsx`
+
+Misión/visión en el home.
+
+---
+
+## `<CTASection>` — `src/components/Homepage/CTA/CTASection.tsx`
+
+CTA final del home con gradiente morado, patrón de puntos y botón a Calendly.
+
+---
+
+## `<Form>` (Contact) — `src/components/ContactUs/Form.tsx`
+
+Formulario de `/contact`. Campos: nombre, email, teléfono, país origen, país destino, programa, cómo nos conociste.
+
+- Envía a `StudentsRecordsService.create()`.
+- Muestra toasts con `react-toastify`.
+- Valida campos requeridos antes de enviar.
+
+---
+
+## Convenciones
+
+- **Client components**: marca con `"use client";` arriba. Solo cuando necesites hooks (`useState`, `useEffect`) o interactividad.
+- **Server components** por default — la mayoría de páginas pueden serlo.
+- **Metadata**: exportar `metadata` desde el page (solo en server components). Si el page es `"use client"`, la metadata va comentada y no aplica — usar un layout por carpeta para metadata SSR.
+- **Imports**: usa aliases `@app/*` y `@src/*`, no rutas relativas.
+- **Estilos**: Tailwind inline. Clases largas están ok — evita crear CSS custom salvo animaciones.

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,0 +1,285 @@
+# Fuentes de datos
+
+Todo lo que se muestra en el sitio viene de una de estas fuentes. Esta guía explica dónde vive cada dato, cómo se lee, y qué otros datos hardcodeados podrían migrarse a Google Sheets para que el staff pueda editarlos sin developer.
+
+---
+
+## Índice
+
+1. [Overview de fuentes](#overview-de-fuentes)
+2. [Maestrías (Google Sheet + Apps Script)](#maestrías-google-sheet-apps-script)
+3. [Licenciaturas (CSV local)](#licenciaturas-csv-local)
+4. [Destinos (TS hardcoded)](#destinos-ts-hardcoded)
+5. [Summer camps (TS hardcoded)](#summer-camps-ts-hardcoded)
+6. [Servicios de estudiante con precios (TS hardcoded en page)](#servicios-de-estudiante-con-precios-ts-hardcoded-en-page)
+7. [Equipo (TS hardcoded en componente)](#equipo-ts-hardcoded-en-componente)
+8. [Textos de categorías (JSON)](#textos-de-categorías-json)
+9. [Logos de aliados (TS hardcoded)](#logos-de-aliados-ts-hardcoded)
+10. [AWS S3: imágenes y assets](#aws-s3-imágenes-y-assets)
+11. [ICEF badge](#icef-badge)
+12. [Formulario de contacto (AWS Lambda)](#formulario-de-contacto-aws-lambda)
+13. [Candidatos para migrar a Sheets](#candidatos-para-migrar-a-sheets)
+
+---
+
+## Overview de fuentes
+
+| Dato | Fuente | Editable por staff | Tiempo hasta verse reflejado |
+|------|--------|--------------------|-----------------------------|
+| Maestrías | Google Sheet vía Apps Script | **Sí** | ~1 min (caché) |
+| Licenciaturas | CSV local (`src/lib/`) | No (requiere PR) | Instantáneo tras deploy |
+| Destinos | `src/data/destinations.ts` | No | Instantáneo tras deploy |
+| Camps | `src/data/summerCampsData.ts` | No | Instantáneo tras deploy |
+| Servicios y precios | `app/estudiante/page.tsx` | No | Instantáneo tras deploy |
+| Equipo | `src/components/Homepage/MeetTeam/MeetTeam.tsx` | No | Instantáneo tras deploy |
+| Texto de categorías | `src/data/categorias_texto.json` | No | Instantáneo tras deploy |
+| Logos aliados | `src/data/constantes.ts` | No | Instantáneo tras deploy |
+| Imágenes | AWS S3 | Indirecto (dev sube archivo, staff manda imagen) | Instantáneo (si URL ya referenciada) |
+| Envíos de contacto | AWS Lambda | Lectura de DB | En vivo |
+
+---
+
+## Maestrías (Google Sheet + Apps Script)
+
+### Flujo
+
+```
+Staff edita Sheet
+      ↓
+Apps Script publicado expone JSON
+      ↓
+Next API route (/api/programs/masters) hace fetch, cachea 1 min
+      ↓
+/programs/masters usa TanStack Query para paginar
+```
+
+### Archivos involucrados
+
+- **`app/api/programs/masters/route.ts`** — API route. Define:
+  - `APPS_SCRIPT_URL` (hardcoded).
+  - `PAGE_SIZE = 30`.
+  - `CACHE_TTL_MS = 60_000`.
+  - Cache en memoria: `cachedRows`.
+  - Fallback: si fetch falla o responde vacío, lee `src/lib/Listado_Masters.csv`.
+- **`src/lib/Listado_Masters.csv`** — copia de respaldo. **Mantenla actualizada** cada cierto tiempo (ver tutorial).
+- **`app/programs/masters/page.tsx`** — consume la API vía `useInfiniteQuery`.
+
+### Formato del Sheet
+
+Headers exactos en la fila 1 (orden importa):
+
+```
+pais | institucion | area | programa | ubicacion | fechas | duracion | costo | moneda | link
+```
+
+### Cómo rotar el URL del Apps Script
+
+Si hay que publicar un nuevo Apps Script (ej. cuenta de Google nueva):
+
+1. En Google Sheets, abre **Extensiones → Apps Script**.
+2. Deploy → New deployment → Web app → "Anyone with the link" → Deploy.
+3. Copia la nueva URL.
+4. En `app/api/programs/masters/route.ts` reemplaza la constante `APPS_SCRIPT_URL`.
+5. Commit + PR.
+
+**Mejor aún**: mover a env var `GOOGLE_APPS_SCRIPT_URL` y leer de `process.env` (ver [TUTORIALES.md](./TUTORIALES.md)).
+
+---
+
+## Licenciaturas (CSV local)
+
+- **Archivo**: `src/lib/Listado_Bachelors.csv` (o el que use `parseLicenciaturas.ts`).
+- **Parser**: `src/lib/parseLicenciaturas.ts`.
+- **API**: `app/api/programs/csv/route.ts`, paginación de 50 por página.
+- **Consumidor**: `app/programs/bachelors/page.tsx`.
+
+Para agregar licenciaturas se edita el CSV en el repo y se hace PR. No es editable por staff. **Candidato** para migrar a Google Sheet (mismo patrón que maestrías).
+
+---
+
+## Destinos (TS hardcoded)
+
+- **Archivo**: `src/data/destinations.ts`.
+- **Forma**:
+  ```ts
+  {
+    name: string;
+    programs: string;        // "45+"
+    flagImage: string;       // URL S3
+    placeImage: string;      // URL S3
+    description: string;
+    educationSystem: string;
+    economy: string;
+    position?: CSSProperties; // para polaroids del Hero home
+  }
+  ```
+- **Consumidores**: `/destinos`, polaroids del Hero del home, dropdowns en el formulario de contacto.
+
+Para agregar/editar un país se hace PR. **Candidato** para Sheet.
+
+---
+
+## Summer camps (TS hardcoded)
+
+- **Archivo**: `src/data/summerCampsData.ts`.
+- **Consumidores**: `/programs/camps`.
+
+Cada camp tiene campos como nombre, edades, fechas, ubicación, duración, costo, proveedor, etc.
+
+**Candidato fuerte** para Sheet — los camps cambian por temporada y el staff los actualiza seguido.
+
+---
+
+## Servicios de estudiante con precios (TS hardcoded en page)
+
+- **Archivo**: `app/estudiante/page.tsx`, const `allServices`.
+- **Forma**:
+  ```ts
+  { id, category, title, description, price, borderColor }
+  ```
+
+Cambios de precio = PR. **Candidato** para Sheet.
+
+---
+
+## Equipo (TS hardcoded en componente)
+
+- **Archivo**: `src/components/Homepage/MeetTeam/MeetTeam.tsx`.
+- **Actualmente**: Paulina Valdés (Founder) y Alejandra Hernández (Co-Founder).
+- **Datos**: nombre, cargo, foto (`/images/*.jpeg` en `public/`), LinkedIn, email, color de acento.
+
+Candidato para Sheet si el equipo va a crecer. Mientras sean 2-3 personas, hardcoded está bien.
+
+---
+
+## Textos de categorías (JSON)
+
+- **Archivo**: `src/data/categorias_texto.json`.
+- **Forma**: mapping `{ "Nombre Categoría": "Descripción completa..." }`.
+- **Consumidor**: página de categoría (ej. Study Tours, Gap Year, etc.).
+
+Fácil de migrar a Sheet (tabla plana `categoria | descripcion`).
+
+---
+
+## Logos de aliados (TS hardcoded)
+
+- **Archivo**: `src/data/constantes.ts`, export `logos`.
+- **Forma**: `{ "University Name": "https://images-bucket.../logo.png" }`.
+- **Consumidor**: `src/components/Footer/Carousel.tsx` (carrusel infinito bajo el footer).
+
+Agregar un logo nuevo = subir PNG a S3 + agregar entrada al TS + PR.
+
+**Candidato** para Sheet con dos columnas (`nombre | url_s3`).
+
+---
+
+## AWS S3: imágenes y assets
+
+- **Bucket**: `images-bucket-landing-page.s3.us-east-2.amazonaws.com`.
+- **Patrón de URL**: `https://{bucket}/public/{categoria}/{nombre}.{ext}`.
+- **Dónde se usan URLs**:
+  - `app/layout.tsx` (OG image del metadata)
+  - `src/components/Navbar/components/Logo.tsx` (logo brand)
+  - `src/data/constantes.ts` (~50+ logos de universidades)
+  - `src/data/destinations.ts` (fotos de países)
+  - Otros componentes según necesidad.
+
+### Cómo subir una imagen nueva
+
+Requiere acceso al bucket S3 (pedir a admin de AWS):
+
+1. Subir el archivo al bucket en el prefijo adecuado (`public/destinos/`, `public/logos/`, etc.).
+2. Hacer el objeto **público** (o usar un bucket policy que los exponga).
+3. Copiar la URL y usarla en código.
+
+Permisos que requiere el objeto: `s3:GetObject` para `*`.
+
+---
+
+## ICEF badge
+
+- **Script externo**: `https://www-cdn.icef.com/scripts/iasbadgeid.js`.
+- **Dónde se inicializa**: `src/components/Footer/Footer.tsx` con `useEffect` que:
+  1. Limpia el contenedor.
+  2. Elimina el `<script>` previo si existe.
+  3. Inyecta el script con query param de cache-bust (`?v=${Date.now()}`) para re-ejecutar el script en cada navegación SPA.
+- **Div anchor**: `<div id="ias_badge" ref={badgeRef} />`.
+
+Si el badge desaparece:
+
+- Verifica que `script` se inyectó inspeccionando `<head>` en DevTools.
+- Verifica que la membresía de ICEF sigue activa (contactar ICEF).
+- Verifica que `www-cdn.icef.com` esté en `next.config.mjs` → `images.remotePatterns` (si sirve imágenes).
+
+---
+
+## Formulario de contacto (AWS Lambda)
+
+- **Endpoint**: `${THEGATE_EDUCATION_API_DOMAIN}/api-students` = `https://mbhyn4didf.execute-api.us-east-2.amazonaws.com/stage/api-students`.
+- **Método**: POST, JSON body.
+- **Archivo cliente**: `src/services/studentsRecords.service.ts`.
+- **Consumidor**: `src/components/ContactUs/Form.tsx`.
+
+Los envíos van a una tabla DynamoDB (inferido por la presencia de `@aws-sdk/client-dynamodb` en deps). Para revisar envíos hay que usar la AWS Console o añadir un dashboard.
+
+---
+
+## Candidatos para migrar a Sheets
+
+El patrón de "Google Sheet → Apps Script → API route → React Query" funciona bien para maestrías. Se puede replicar para cualquier otro dato tabular hardcodeado. Priorizado por impacto:
+
+### 1. **Licenciaturas** — impacto alto, esfuerzo bajo
+
+Ya existe un CSV (`src/lib/Listado_Bachelors.csv`) y un parser. Migrar a Sheet sería prácticamente copiar la estructura de maestrías. El staff podría actualizar licenciaturas igual que maestrías, sin PR. **Recomendado primero.**
+
+### 2. **Summer camps** — impacto alto, esfuerzo medio
+
+Los camps cambian cada temporada. Staff terminó editando el TS con ayuda de dev. Una tabla con columnas `nombre | edades | fechas | ciudad | duracion | costo | proveedor | extras | link` es directa. **Recomendado segundo.**
+
+### 3. **Servicios de estudiante / precios** — impacto medio, esfuerzo bajo
+
+Tabla muy plana: `id | categoria | titulo | descripcion | precio | color_borde`. Marketing puede querer ajustar precios por temporada o campaña sin esperar un PR.
+
+### 4. **Destinos** — impacto medio, esfuerzo medio
+
+Más complejo porque tiene campos largos (descripción, sistema educativo, economía) y campos visuales (`position` CSS para polaroids). Migrar solo los campos textuales es factible; mantener los CSS positions en código.
+
+### 5. **Logos de aliados** — impacto bajo, esfuerzo bajo
+
+Tabla `nombre | url_imagen`. Fácil, pero el flujo de subir el archivo a S3 sigue requiriendo dev.
+
+### 6. **Textos de categorías** — impacto bajo
+
+`src/data/categorias_texto.json` se toca pocas veces. No es urgente migrar.
+
+### 7. **Equipo** — bajo
+
+Si el equipo se queda en 2-3 personas, no vale la pena.
+
+---
+
+### Receta genérica para migrar X a Sheets
+
+Paso a paso, tomando maestrías como plantilla:
+
+1. **Crear Sheet** con headers en fila 1. Los nombres deben coincidir con los que espera el parser.
+2. **Crear Apps Script** (Extensiones → Apps Script) que expone el Sheet como JSON. Ejemplo mínimo:
+   ```js
+   function doGet() {
+     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Hoja1");
+     const [headers, ...rows] = sheet.getDataRange().getValues();
+     const data = rows.map(row =>
+       Object.fromEntries(headers.map((h, i) => [h, row[i]]))
+     );
+     return ContentService.createTextOutput(JSON.stringify(data))
+       .setMimeType(ContentService.MimeType.JSON);
+   }
+   ```
+3. **Deploy** el Apps Script como Web App ("Anyone with the link").
+4. **Crear API route** `app/api/programs/{recurso}/route.ts` copiando la estructura de `masters/route.ts`. Cambia: URL, tipo del item, headers esperados, CSV fallback opcional.
+5. **Actualizar página** `app/programs/{recurso}/page.tsx` o equivalente para consumir la nueva API con React Query.
+6. **Borrar el TS/JSON hardcoded** cuando la migración esté verificada en producción.
+7. **Documentar** en este archivo cómo editar el Sheet nuevo.
+
+Paso detallado en [TUTORIALES.md § Migrar datos hardcoded a Google Sheets](./TUTORIALES.md#migrar-datos-hardcoded-a-google-sheets).

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -227,6 +227,8 @@ Los envíos van a una tabla DynamoDB (inferido por la presencia de `@aws-sdk/cli
 
 ## Candidatos para migrar a Sheets
 
+> **Estado**: propuesta / roadmap para el futuro. Ninguno de los siguientes está implementado todavía. Cuando haya tiempo (o cuando el staff empiece a pedir muchos cambios de algún dataset concreto), se puede ejecutar siguiendo el [tutorial paso a paso en TUTORIALES.md](./TUTORIALES.md#ejemplo-trabajado-migrar-destinos-a-sheets-guía-para-futuros-devs).
+
 El patrón de "Google Sheet → Apps Script → API route → React Query" funciona bien para maestrías. Se puede replicar para cualquier otro dato tabular hardcodeado. Priorizado por impacto:
 
 ### 1. **Licenciaturas** — impacto alto, esfuerzo bajo
@@ -259,27 +261,17 @@ Si el equipo se queda en 2-3 personas, no vale la pena.
 
 ---
 
-### Receta genérica para migrar X a Sheets
+---
 
-Paso a paso, tomando maestrías como plantilla:
+### Resumen de decisión
 
-1. **Crear Sheet** con headers en fila 1. Los nombres deben coincidir con los que espera el parser.
-2. **Crear Apps Script** (Extensiones → Apps Script) que expone el Sheet como JSON. Ejemplo mínimo:
-   ```js
-   function doGet() {
-     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Hoja1");
-     const [headers, ...rows] = sheet.getDataRange().getValues();
-     const data = rows.map(row =>
-       Object.fromEntries(headers.map((h, i) => [h, row[i]]))
-     );
-     return ContentService.createTextOutput(JSON.stringify(data))
-       .setMimeType(ContentService.MimeType.JSON);
-   }
-   ```
-3. **Deploy** el Apps Script como Web App ("Anyone with the link").
-4. **Crear API route** `app/api/programs/{recurso}/route.ts` copiando la estructura de `masters/route.ts`. Cambia: URL, tipo del item, headers esperados, CSV fallback opcional.
-5. **Actualizar página** `app/programs/{recurso}/page.tsx` o equivalente para consumir la nueva API con React Query.
-6. **Borrar el TS/JSON hardcoded** cuando la migración esté verificada en producción.
-7. **Documentar** en este archivo cómo editar el Sheet nuevo.
+- **Empezar por cualquiera depende de qué pida más el staff.** Si te están pidiendo cambios frecuentes de camps, empieza por ahí. Si piden precios, por ahí.
+- **Sugerencia consolidada**: un solo Google Sheet llamado por ejemplo "TheGate Contenido" con **varias pestañas** — una pestaña por dataset (`maestrias`, `licenciaturas`, `destinos`, `camps`, `precios`, etc.). El staff tiene un solo link que bookmarkean, en vez de N Sheets distintos. Cada pestaña se lee desde su propia API route.
+- **Cuándo NO migrar**: datos que casi nunca cambian (equipo con 2-3 personas, textos legales, aviso de privacidad). El costo de mantener otra pestaña supera el beneficio.
 
-Paso detallado en [TUTORIALES.md § Migrar datos hardcoded a Google Sheets](./TUTORIALES.md#migrar-datos-hardcoded-a-google-sheets).
+### Cómo se hace
+
+Dos tutoriales en [TUTORIALES.md](./TUTORIALES.md):
+
+- [Receta genérica](./TUTORIALES.md#migrar-datos-hardcoded-a-google-sheets) — los 5 pasos en abstracto.
+- [Ejemplo trabajado: migrar destinos](./TUTORIALES.md#ejemplo-trabajado-migrar-destinos-a-sheets-guía-para-futuros-devs) — seguimiento línea por línea de cómo se haría destinos. Úsalo como plantilla para replicar cualquier otro dataset.

--- a/docs/MANUAL_USUARIO.md
+++ b/docs/MANUAL_USUARIO.md
@@ -1,0 +1,183 @@
+# Manual de Usuario — Staff de The Gate
+
+Guía para quien administra contenido del sitio **sin necesidad de programar**. Si eres developer, ve a [ARQUITECTURA.md](./ARQUITECTURA.md).
+
+---
+
+## Índice
+
+1. [Qué puedes editar tú directamente](#qué-puedes-editar-tú-directamente)
+2. [Editar el catálogo de maestrías (Google Sheet)](#editar-el-catálogo-de-maestrías-google-sheet)
+3. [Pedir cambios al equipo de desarrollo](#pedir-cambios-al-equipo-de-desarrollo)
+4. [Revisar que el sitio funcione bien](#revisar-que-el-sitio-funcione-bien)
+5. [Formulario de contacto: dónde llegan los mensajes](#formulario-de-contacto-dónde-llegan-los-mensajes)
+6. [Preguntas frecuentes](#preguntas-frecuentes)
+
+---
+
+## Qué puedes editar tú directamente
+
+Hoy puedes modificar **sin ayuda de un developer**:
+
+| Qué | Dónde | Se refleja en el sitio en... |
+|-----|-------|-----------------------------|
+| Catálogo de maestrías (países, programas, precios, duración, link) | Google Sheet compartido | ~1 minuto (caché del servidor) |
+
+**Todo lo demás** (textos del hero, miembros del equipo, destinos, precios de servicios, noticias, logos de aliados) **requiere pedírselo al developer**. Esa lista puede crecer — ve [Candidatos para migrar a Sheets](./DATA.md#candidatos-para-migrar-a-sheets) para saber qué se podría hacer auto-editable en el futuro.
+
+---
+
+## Editar el catálogo de maestrías (Google Sheet)
+
+Esta es la única parte del sitio que puedes cambiar tú sin tocar código. El sitio lee directamente el Google Sheet cada vez que alguien visita `/programs/masters`.
+
+### 1. Abrir el Sheet
+
+El Sheet está enlazado al Apps Script que consume el sitio. Pídele al owner del proyecto (Paulina o el developer principal) que te comparta acceso de **edición** al spreadsheet de "Listado Masters".
+
+### 2. Estructura de columnas
+
+El Sheet **debe** tener exactamente estas columnas, en este orden, en la fila 1:
+
+| Columna | Ejemplo | Notas |
+|---------|---------|-------|
+| `pais` | `Australia` | Nombre del país, primera letra en mayúscula |
+| `institucion` | `University of Sydney` | Nombre oficial de la institución |
+| `area` | `Business` | Área de estudio (Business, Engineering, Health, Arts, Sciences, etc.) |
+| `programa` | `Master of Business Administration` | Nombre del programa en el idioma original |
+| `ubicacion` | `Sydney, NSW` | Ciudad / estado |
+| `fechas` | `Feb / Jul` | Meses de inicio. Usa `/` para separar |
+| `duracion` | `1 año` o `18 meses` | Duración total |
+| `costo` | `48000` | Solo el número, sin símbolos. Si no hay info, deja vacío |
+| `moneda` | `AUD` | Código ISO de 3 letras (USD, GBP, EUR, AUD, CAD...) |
+| `link` | `https://www.sydney.edu.au/...` | URL directa al programa en el sitio de la institución |
+
+> **No cambies los nombres de las columnas.** Si los cambias, el sitio deja de leer los datos.
+
+### 3. Agregar una maestría nueva
+
+1. Ve a la última fila con contenido.
+2. Agrega una nueva fila con todos los datos. No dejes filas vacías en medio (el parser se puede confundir).
+3. Guarda — Google Sheets guarda automático.
+4. Espera ~1 minuto y refresca `/programs/masters` en el sitio. Deberías ver el nuevo programa.
+
+### 4. Modificar un programa existente
+
+1. Encuentra la fila del programa (puedes usar `Ctrl+F` en Google Sheets).
+2. Edita las celdas que necesites.
+3. Espera ~1 minuto, refresca `/programs/masters`.
+
+### 5. Eliminar un programa
+
+1. Selecciona la fila completa.
+2. Clic derecho → "Eliminar fila".
+3. **No dejes la fila vacía** — borra la fila entera, no solo el contenido.
+
+### 6. Si algo se rompe
+
+Si después de tus cambios la página `/programs/masters` muestra menos programas o un error:
+
+- Revisa que los **nombres de las columnas** en la fila 1 no hayan cambiado.
+- Revisa que no haya **filas vacías entre datos**.
+- Revisa que la columna `costo` tenga solo números (sin comas, sin `$`, sin texto).
+- Si todo se ve bien pero sigue fallando, el sitio automáticamente usa una copia de respaldo (CSV) que el developer mantiene — contáctalo para que actualice el respaldo o investigue.
+
+---
+
+## Pedir cambios al equipo de desarrollo
+
+Para cualquier cosa que no sea el Sheet de maestrías, escribe un mensaje claro al developer. Un buen ticket lleva:
+
+1. **Qué quieres cambiar**: ej. "El precio del servicio 'Revisión de CV' en la página /estudiante".
+2. **Valor actual**: ej. "$5 USD".
+3. **Valor nuevo**: ej. "$8 USD".
+4. **Ejemplo / referencia** si aplica: screenshot del lugar, link al documento de marca, etc.
+
+**Ejemplos de cambios comunes que requieren developer:**
+
+- Cambiar un miembro del equipo (foto, nombre, cargo, LinkedIn).
+- Modificar el texto principal del home ("Donde hay una puerta abierta...").
+- Agregar o quitar un país de la página de destinos.
+- Cambiar el precio de un servicio en `/estudiante`.
+- Actualizar un logo de aliado en el carrusel.
+- Agregar una noticia o actualización.
+- Cambiar el link de Calendly (actualmente `calendly.com/thegateeducation/30min`).
+
+**Tiempo esperado**: un cambio de texto/precio típico toma menos de 1 día. Un cambio grande (rediseño de sección) puede tomar una semana.
+
+---
+
+## Revisar que el sitio funcione bien
+
+Cada vez que el developer suba un cambio importante, revisa:
+
+### Checklist rápido (5 min)
+
+1. Abre [the-gate-main-page.vercel.app](https://the-gate-main-page.vercel.app) (o el dominio actual de producción).
+2. Verifica el **home**: se ve el hero con el texto correcto, los países flotantes, los CTAs funcionan (click en "Explorar Programas" → te lleva a `/programs`).
+3. Verifica **`/programs/masters`**: se ven maestrías, puedes filtrar por país/área, los links de "Ver programa" abren la página de la institución.
+4. Verifica el **footer**: aparece el **badge de ICEF** (QR verde/azul abajo a la derecha). Si no aparece, avisa al dev — es tema técnico del script externo.
+5. Llena y envía el **formulario de contacto** con datos de prueba. Debe salir un toast verde de "Mensaje enviado".
+6. Revisa en **móvil** (o en DevTools con `F12` → modo móvil): el navbar se convierte en menú hamburguesa, las cards se apilan bien.
+
+### Cosas que son **normales** y no hace falta reportar
+
+- La primera vez que cargas una página grande (maestrías), tarda un par de segundos — es Next.js cargando la data.
+- El carrusel de aliados se detiene si pasas el mouse encima.
+
+### Cosas que **sí** hace falta reportar
+
+- Texto cortado o tapado por otro elemento.
+- Imágenes rotas (aparece un ícono gris).
+- Links que dan error 404.
+- El formulario de contacto no responde al enviar.
+- El badge de ICEF del footer no aparece en alguna página.
+
+---
+
+## Formulario de contacto: dónde llegan los mensajes
+
+El formulario de `/contact` envía los datos a un servicio externo (AWS Lambda). No llegan a un correo directo — se guardan en una base de datos que revisa el equipo de desarrollo / admin.
+
+**Para recibir notificaciones por correo** de nuevos contactos, pídeselo al developer — requiere configurar un webhook adicional.
+
+**Campos que captura el formulario**:
+- Nombre, email, teléfono
+- País de origen / país de destino
+- Programa de interés (maestría, licenciatura, camp, etc.)
+- Cómo nos conociste
+
+---
+
+## Preguntas frecuentes
+
+### ¿Puedo tener acceso al código?
+
+No necesitas. El acceso al Google Sheet es suficiente para el 99% de tus tareas de contenido. El resto pásaselo al developer.
+
+### ¿Qué hago si el sitio está caído?
+
+Revisa en orden:
+1. ¿Tienes internet? (Suena obvio, pasa seguido).
+2. ¿Está caído solo para ti o también para otros? Pregunta a un compañero.
+3. Si está caído para todos, escríbele al developer — probablemente es un issue de Vercel o del DNS.
+
+### ¿Puedo agregar una página nueva sola?
+
+No — agregar una página nueva requiere código. Pide al developer.
+
+### ¿Quién actualiza el badge de ICEF?
+
+El badge se renueva automático desde el servidor de ICEF. **No requiere mantenimiento**. Si desaparece o expira, contacta al developer — puede ser que la membresía de ICEF haya vencido y hay que renovarla con ICEF directamente.
+
+### ¿Dónde están guardadas las imágenes?
+
+En un bucket de AWS S3 (`images-bucket-landing-page`). Para subir una imagen nueva necesitas al developer. Cuando entregues imágenes:
+
+- Formato: **JPG** para fotos, **PNG** con fondo transparente para logos.
+- Tamaño máximo recomendado: **500 KB** por imagen.
+- Dimensiones: dile al dev qué sección es y él/ella ajusta.
+
+### ¿Con quién contacto para presupuesto o cambios grandes?
+
+Con el owner del proyecto (Paulina Valdés / Alejandra Hernández), no con el developer directo.

--- a/docs/PAGINAS.md
+++ b/docs/PAGINAS.md
@@ -1,0 +1,228 @@
+# Páginas
+
+Referencia de cada ruta del sitio: qué muestra, qué data consume, qué componentes usa. Archivos referenciados con ruta desde la raíz del repo.
+
+---
+
+## Home — `/`
+
+**Archivo**: `app/page.tsx`
+
+**Qué muestra**: landing principal. Hero fullscreen + secciones en scroll.
+
+**Secciones** (en orden):
+
+1. `<Hero fullHeight showCTA>` — gradiente morado, título "Donde hay una puerta abierta...", CTAs "Explorar Programas" + "Agenda tu Asesoría", polaroids flotantes de países, ola inferior.
+2. `<Destinations>` — grid de tarjetas de países.
+3. `<Programs>` — categorías de programas con descripción.
+4. `<Stadistics>` — números (países, instituciones, aceptación) + sección de preguntas.
+5. `<MeetTeam>` — Paulina y Alejandra con LinkedIn/email.
+6. `<MissionVision>` — misión / visión.
+7. `<CTASection>` — CTA final con gradiente morado.
+
+**Data**:
+- `src/data/destinations.ts` para `<Destinations>` y los polaroids del Hero.
+- Miembros del equipo hardcoded en `src/components/Homepage/MeetTeam/MeetTeam.tsx`.
+- Textos hardcoded en los componentes del home.
+
+---
+
+## `/programs` — Hub de programas
+
+**Archivo**: `app/programs/page.tsx`
+
+**Qué muestra**: listado de categorías de programas (maestrías, licenciaturas, camps, intercambios, idiomas, etc.) como cards. Cada card enlaza a la sub-ruta correspondiente.
+
+**Data**: `src/data/constantes.ts` (categorías) + `src/data/categorias_texto.json` (textos descriptivos).
+
+**Componentes**: Hero con style rich + grid de `<CategoryCard>`.
+
+---
+
+## `/programs/masters` — Catálogo de maestrías
+
+**Archivo**: `app/programs/masters/page.tsx`
+
+**Qué muestra**: listado paginado de maestrías con filtros por país y por área. Cada resultado muestra institución, programa, ubicación, fechas, duración, costo, link al programa oficial.
+
+**Data**:
+- Fuente principal: **Google Apps Script** publicado desde el Sheet "Listado Masters".
+- API route: `app/api/programs/masters/route.ts` — intenta Apps Script primero, si falla usa CSV local `src/lib/Listado_Masters.csv`.
+- Paginación: 30 items por página, cursor `nextKey`.
+- Cache en memoria del servidor: 1 minuto (`CACHE_TTL_MS`).
+
+**Componentes**:
+- `<Hero>` con style rich.
+- `<ProgramPage>` (container con filtros + infinite scroll vía React Query).
+- `<ProgramCardsPorArea>` para renderizar cada card.
+
+**Ver también**: [DATA.md § Maestrías](./DATA.md#maestrías-google-sheet-apps-script) + [TUTORIALES.md § Editar el Sheet de maestrías](./TUTORIALES.md#editar-el-google-sheet-de-maestrías-staff).
+
+---
+
+## `/programs/bachelors` — Licenciaturas
+
+**Archivo**: `app/programs/bachelors/page.tsx`
+
+**Qué muestra**: listado paginado de licenciaturas, filtrable por país/área.
+
+**Data**:
+- Fuente: CSV local `src/lib/Listado_Bachelors.csv` (si existe) o endpoint AWS Lambda, según la config actual.
+- API route: `app/api/programs/csv/route.ts` — parser `src/lib/parseLicenciaturas.ts`, 50 items por página.
+- **No** usa Google Sheet (hoy). Candidato para migrar — ver [DATA.md § Candidatos para migrar a Sheets](./DATA.md#candidatos-para-migrar-a-sheets).
+
+**Componentes**: `<Hero>`, `<ProgramPage>`, `<ProgramCardsPorArea>`.
+
+---
+
+## `/programs/camps` — Summer camps
+
+**Archivo**: `app/programs/camps/page.tsx`
+
+**Qué muestra**: catálogo de campamentos de verano filtrable por edad.
+
+**Data**: `src/data/summerCampsData.ts` (hardcoded).
+
+**Componentes**: `<Hero>` + `<SummerCampCards>` + `<ProgramCardsPorEdades>`.
+
+---
+
+## `/destinos` — Países
+
+**Archivo**: `app/destinos/page.tsx`
+
+**Qué muestra**: Hero rich + grid de países con descripción educativa/económica + stats.
+
+**Data**: `src/data/destinations.ts`. Cada país tiene:
+
+```ts
+{
+  name: string;
+  programs: string;       // "45+"
+  flagImage: string;      // URL S3
+  placeImage: string;     // URL S3, foto del lugar
+  description: string;
+  educationSystem: string;
+  economy: string;
+  position?: CSSProperties;  // solo los 6 primeros, para polaroids del Hero home
+}
+```
+
+**Componentes**: `<Hero>`, cards custom inline en el page.
+
+---
+
+## `/services` — Servicios
+
+**Archivo**: `app/services/page.tsx`
+
+**Qué muestra**: servicios que ofrece The Gate (asesoría, revisiones, etc.) como cards con CTA.
+
+**Data**: hardcoded en el page + `src/components/Services/CardCTA.tsx`.
+
+---
+
+## `/estudiante` — Tabla de servicios para estudiantes
+
+**Archivo**: `app/estudiante/page.tsx`
+
+**Qué muestra**: tabla interactiva de servicios con precios agrupados en "Gratuitos", "Servicios Completos", "Servicios por Separado". Checkbox en cada card para armar un carrito visual (SummaryCard).
+
+**Data**: **hardcoded** en la const `allServices` del propio page. Cada servicio:
+
+```ts
+{
+  id: number;
+  category: string;
+  title: string;
+  description: string;
+  price: number;  // en USD, 0 = Gratis
+  borderColor: string;
+}
+```
+
+**Componentes**: `<Hero>`, `<ServiceCard>`, `<SummaryCard>`.
+
+**Nota**: los precios están en código. Cualquier cambio requiere PR. Candidato para Sheets — ver [DATA.md § Candidatos para migrar a Sheets](./DATA.md#candidatos-para-migrar-a-sheets).
+
+---
+
+## `/alianzas` — Alianzas estratégicas
+
+**Archivo**: `app/alianzas/page.tsx`
+
+**Qué muestra**: Hero + explicación del programa de alianzas + beneficios.
+
+**Data**: hardcoded en el page.
+
+---
+
+## `/instituciones` — Para instituciones
+
+**Archivo**: `app/instituciones/page.tsx`
+
+**Qué muestra**: Hero rich (fondo de campus) + lista de servicios que The Gate ofrece a instituciones educativas aliadas + CTA final.
+
+**Data**: hardcoded en el page (array `servicesData` + `beneficios`).
+
+---
+
+## `/about` — Acerca de
+
+**Archivo**: `app/about/page.tsx`
+
+**Qué muestra**: información general sobre The Gate. Página sencilla.
+
+---
+
+## `/contact` — Contacto
+
+**Archivo**: `app/contact/page.tsx`
+
+**Qué muestra**: formulario de contacto grande con muchos campos (nombre, email, país origen/destino, programa, etc.).
+
+**Data enviada a**: AWS Lambda vía `StudentsRecordsService.create()` → `POST ${THEGATE_EDUCATION_API_DOMAIN}/api-students`.
+
+**Componentes**: `<ContactUs/Form>`.
+
+**Feedback**: toasts (react-toastify) para éxito/error.
+
+---
+
+## `/news` — Noticias
+
+**Archivo**: `app/news/page.tsx`
+
+**Qué muestra**: placeholder "Próximamente aquí". No consume datos externos.
+
+**Cuando se active**: requiere decidir CMS (Sheets, Sanity, Notion API, etc.) o hardcoded. Ver [TUTORIALES.md § Activar la sección de noticias](./TUTORIALES.md#activar-la-sección-de-noticias).
+
+---
+
+## `/aviso-de-privacidad` — Aviso legal
+
+**Archivo**: `app/aviso-de-privacidad/page.tsx`
+
+**Qué muestra**: texto legal estático.
+
+**Data**: hardcoded.
+
+---
+
+## API routes
+
+### `GET /api/programs/masters`
+
+**Archivo**: `app/api/programs/masters/route.ts`
+
+- Query params: `?nextKey=...&pageSize=30&country=...&area=...`.
+- Respuesta: `{ items: Master[], nextKey?: string }`.
+- Flujo: intenta Apps Script → si falla, parsea CSV fallback → cache en memoria 1 min.
+
+### `GET /api/programs/csv`
+
+**Archivo**: `app/api/programs/csv/route.ts`
+
+- Query params: `?nextKey=...&pageSize=50&country=...&area=...`.
+- Respuesta: `{ items: Bachelor[], nextKey?: string }`.
+- Flujo: parsea `src/lib/Listado_Bachelors.csv` (o similar) vía `parseLicenciaturas.ts`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Documentación — The Gate Education
+
+Esta carpeta contiene toda la documentación del sitio web. Cada archivo tiene una audiencia específica — empieza por el que corresponde a tu rol.
+
+## Si eres **staff no técnico** (ej. editas contenido, respondes correos)
+
+Lee esto:
+
+- **[MANUAL_USUARIO.md](./MANUAL_USUARIO.md)** — cómo editar maestrías vía Google Sheets, cómo pedir cambios al equipo de desarrollo, flujo del formulario de contacto, qué hacer si algo se ve mal.
+- **[TUTORIALES.md](./TUTORIALES.md)** — secciones marcadas "(para staff)" con pasos ilustrados.
+
+## Si eres **developer** (mantienes o extiendes el código)
+
+Empieza aquí y sigue el orden:
+
+1. **[ARQUITECTURA.md](./ARQUITECTURA.md)** — stack, estructura de carpetas, setup local, deploy en Vercel, convenciones.
+2. **[PAGINAS.md](./PAGINAS.md)** — qué hace cada ruta del sitio.
+3. **[DATA.md](./DATA.md)** — de dónde vienen los datos (JSON, Google Sheets, AWS, S3).
+4. **[COMPONENTES.md](./COMPONENTES.md)** — componentes reutilizables y sus props.
+5. **[TUTORIALES.md](./TUTORIALES.md)** — recetas para tareas comunes: agregar destino, migrar un dato hardcoded a Sheets, etc.
+
+## Convenciones de este repo
+
+- Rama default: **`development`**. No hay `main` remoto — todo se mergea a `development` y de ahí Vercel despliega a producción.
+- Los PRs van de una rama feature hacia `development`.
+- Paleta: morado `#5F338B`, naranja `#EDA74C`. Definidos también como `customPurple` y `customOrange` en `tailwind.config.ts`.
+- Idioma del sitio y de la documentación: español.
+
+## Mantener esta documentación
+
+Cuando cambies algo no-trivial (una ruta nueva, una fuente de datos nueva, un env var nuevo), abre un commit en el mismo PR que toque el archivo correspondiente aquí. La documentación desactualizada engaña más de lo que ayuda.

--- a/docs/TUTORIALES.md
+++ b/docs/TUTORIALES.md
@@ -1,0 +1,367 @@
+# Tutoriales
+
+Recetas paso-a-paso para tareas comunes. Las que dicen **(staff)** las puede hacer cualquiera con acceso al Sheet; las demás requieren dev con acceso al repo.
+
+---
+
+## Índice
+
+### Para staff
+- [Editar el Google Sheet de maestrías](#editar-el-google-sheet-de-maestrías-staff)
+
+### Para developers — cambios de contenido
+- [Cambiar el texto del Hero en el home](#cambiar-el-texto-del-hero-en-el-home)
+- [Actualizar miembros del equipo](#actualizar-miembros-del-equipo)
+- [Agregar o editar un destino](#agregar-o-editar-un-destino)
+- [Cambiar un precio en /estudiante](#cambiar-un-precio-en-estudiante)
+- [Agregar un logo nuevo al carrusel de aliados](#agregar-un-logo-nuevo-al-carrusel-de-aliados)
+- [Actualizar el catálogo de licenciaturas](#actualizar-el-catálogo-de-licenciaturas)
+- [Actualizar summer camps](#actualizar-summer-camps)
+- [Activar la sección de noticias](#activar-la-sección-de-noticias)
+
+### Para developers — infraestructura
+- [Mover endpoints hardcoded a variables de entorno](#mover-endpoints-hardcoded-a-variables-de-entorno)
+- [Rotar el URL del Apps Script de maestrías](#rotar-el-url-del-apps-script-de-maestrías)
+- [Actualizar el CSV fallback de maestrías](#actualizar-el-csv-fallback-de-maestrías)
+- [Migrar datos hardcoded a Google Sheets](#migrar-datos-hardcoded-a-google-sheets)
+- [Subir una imagen nueva a S3](#subir-una-imagen-nueva-a-s3)
+- [Deploy de emergencia / rollback](#deploy-de-emergencia--rollback)
+
+---
+
+## Editar el Google Sheet de maestrías (staff)
+
+> Audiencia: **staff no-técnico**. Asume acceso de edición al Sheet.
+
+1. Abre el Sheet compartido ("Listado Masters").
+2. Ve a la hoja con los programas.
+3. Agregar un programa → scroll al final, nueva fila con los 10 campos en orden:
+   `pais, institucion, area, programa, ubicacion, fechas, duracion, costo, moneda, link`.
+4. Editar un programa → buscar la fila (`Ctrl+F`), modificar celdas.
+5. Borrar un programa → clic derecho en la fila → "Eliminar fila". **No dejes filas vacías en medio.**
+6. Esperar ~1 minuto y refrescar `/programs/masters`.
+
+Problemas comunes → ver [MANUAL_USUARIO.md § Si algo se rompe](./MANUAL_USUARIO.md#6-si-algo-se-rompe).
+
+---
+
+## Cambiar el texto del Hero en el home
+
+1. Abre `app/page.tsx`.
+2. Modifica los props del `<Hero>`:
+   ```tsx
+   <Hero
+     title="Tu nuevo título aquí"
+     subtitle="Tu nuevo subtítulo aquí"
+     showCTA
+     fullHeight
+   />
+   ```
+3. Verifica el largo del título — si es demasiado largo rompe el layout móvil. Prueba en DevTools con viewport móvil.
+4. Commit con mensaje `fix: update home hero copy` y PR a `development`.
+
+---
+
+## Actualizar miembros del equipo
+
+1. Abre `src/components/Homepage/MeetTeam/MeetTeam.tsx`.
+2. Busca el array de miembros (líneas ~17–43). Cada entrada:
+   ```ts
+   {
+     name: "Nombre Apellido",
+     role: "Cargo",
+     image: "/images/foto.jpeg",    // o URL S3
+     linkedin: "https://linkedin.com/in/...",
+     email: "correo@thegateeducation.com",
+     color: "#5F338B",              // acento
+   }
+   ```
+3. Para una foto nueva:
+   - Opción A (rápida): copiar la imagen a `public/images/nombre.jpeg` en el repo. Usar `/images/nombre.jpeg` como src.
+   - Opción B (preferida): subirla a S3 (ver [Subir una imagen nueva a S3](#subir-una-imagen-nueva-a-s3)) y usar la URL completa.
+4. Commit `feat: add {nombre} to team` y PR.
+
+---
+
+## Agregar o editar un destino
+
+1. Abre `src/data/destinations.ts`.
+2. Duplica un destino existente y ajusta:
+   ```ts
+   {
+     name: "Nombre País",
+     programs: "XX+",
+     flagImage: "https://images-bucket.../public/flags/xx.png",
+     placeImage: "https://images-bucket.../public/destinos/xx.jpg",
+     description: "...",
+     educationSystem: "...",
+     economy: "...",
+     // position: { ... }  ← solo si quieres que aparezca como polaroid en el Hero home
+   }
+   ```
+3. Solo los primeros 6 destinos con `position` aparecen como polaroids flotantes en el Hero del home. `src/components/Hero/Hero.tsx` los toma con `.filter(d => d.position).slice(0, 6)`.
+4. Commit y PR.
+
+---
+
+## Cambiar un precio en /estudiante
+
+1. Abre `app/estudiante/page.tsx`.
+2. Busca la const `allServices`.
+3. Encuentra el servicio por `title` y cambia `price` (número, en USD; `0` = Gratis).
+4. Commit `fix: update price for {servicio}`.
+
+> Candidato fuerte para migrar a Sheets — ver [DATA.md § Candidatos para migrar a Sheets](./DATA.md#candidatos-para-migrar-a-sheets).
+
+---
+
+## Agregar un logo nuevo al carrusel de aliados
+
+1. Sube el PNG (fondo transparente) al bucket S3 en `public/logos/` (ver [Subir una imagen nueva a S3](#subir-una-imagen-nueva-a-s3)).
+2. Abre `src/data/constantes.ts`, busca el export `logos` (objeto).
+3. Agrega una entrada:
+   ```ts
+   "Nombre Institución": "https://images-bucket-landing-page.s3.us-east-2.amazonaws.com/public/logos/nuevo.png",
+   ```
+4. Commit `feat: add {institución} logo to partners carousel` y PR.
+
+---
+
+## Actualizar el catálogo de licenciaturas
+
+1. Abre el CSV en `src/lib/Listado_Bachelors.csv` (o el archivo que use `src/lib/parseLicenciaturas.ts`).
+2. Agregar / editar filas manteniendo exactamente los headers.
+3. Commit `chore: refresh bachelors catalog` y PR.
+
+> Este es el flujo actual. Migrar a Sheet es un proyecto recomendado — ver [Migrar datos hardcoded a Google Sheets](#migrar-datos-hardcoded-a-google-sheets).
+
+---
+
+## Actualizar summer camps
+
+1. Abre `src/data/summerCampsData.ts`.
+2. Ajustar los camps existentes o agregar objetos nuevos manteniendo la shape.
+3. Commit y PR.
+
+> **Recomendación**: estos datos cambian por temporada. Migrar a Sheets beneficia mucho aquí.
+
+---
+
+## Activar la sección de noticias
+
+Actualmente `/news` es un placeholder ("Próximamente aquí"). Opciones para activarlo:
+
+### Opción A — Sheet + Apps Script (consistente con maestrías)
+
+1. Crear Sheet "Noticias" con columnas `titulo | fecha | resumen | cuerpo | imagen_url | link`.
+2. Publicar Apps Script como Web App.
+3. Crear `app/api/news/route.ts` con la misma estructura de `masters/route.ts`.
+4. Convertir `app/news/page.tsx` en server component que consuma la API.
+
+### Opción B — MDX en el repo
+
+Crear `content/news/*.mdx` con frontmatter. Instalar `@next/mdx`. Cada PR agrega una noticia nueva. Más limpio pero requiere dev para cada post.
+
+### Opción C — CMS externo (Sanity, Notion, Contentful)
+
+Overkill para The Gate hoy, a menos que se planee publicar semanalmente. No recomendado todavía.
+
+**Recomendación**: Opción A si ya tenemos el patrón de Sheets andando.
+
+---
+
+## Mover endpoints hardcoded a variables de entorno
+
+Varios endpoints están hardcoded en el código. Para rotarlos o usar una URL distinta en staging vs prod, conviene moverlos a env vars.
+
+1. Crear `.env.local` en la raíz del repo (y agregarlo a `.gitignore` si no está ya):
+   ```env
+   GOOGLE_APPS_SCRIPT_URL=https://script.google.com/macros/s/.../exec
+   THEGATE_API_DOMAIN=https://mbhyn4didf.execute-api.us-east-2.amazonaws.com/stage
+   ```
+2. En `app/api/programs/masters/route.ts` reemplazar:
+   ```ts
+   const APPS_SCRIPT_URL = process.env.GOOGLE_APPS_SCRIPT_URL!;
+   ```
+3. En `src/config/env.ts` reemplazar el valor por:
+   ```ts
+   export const THEGATE_EDUCATION_API_DOMAIN =
+     process.env.THEGATE_API_DOMAIN ?? "https://mbhyn4didf.execute-api.us-east-2.amazonaws.com/stage";
+   ```
+4. En **Vercel** (Project Settings → Environment Variables) agregar las mismas keys con sus valores tanto en Production como en Preview.
+5. Commit y PR.
+
+Beneficio: rotar la URL del Apps Script ya no requiere commit — se cambia en Vercel y redeploy.
+
+---
+
+## Rotar el URL del Apps Script de maestrías
+
+Si Google invalida el deployment actual (o la cuenta cambia):
+
+1. Abrir el Sheet → Extensiones → Apps Script.
+2. En el editor: Deploy → **New deployment** → Type: Web app.
+3. Settings:
+   - Execute as: **Me** (o la cuenta service).
+   - Who has access: **Anyone with the link**.
+4. Deploy → copiar la nueva URL.
+5. Si ya hiciste [Mover endpoints hardcoded a variables de entorno](#mover-endpoints-hardcoded-a-variables-de-entorno): actualizar `GOOGLE_APPS_SCRIPT_URL` en Vercel y redeploy. **Sin commit**.
+6. Si sigue hardcoded: editar `app/api/programs/masters/route.ts` → `APPS_SCRIPT_URL` → commit + PR.
+
+---
+
+## Actualizar el CSV fallback de maestrías
+
+El CSV `src/lib/Listado_Masters.csv` se usa automáticamente cuando el Apps Script falla. Se recomienda refrescarlo cada ~mes:
+
+1. En el Sheet de maestrías: Archivo → Descargar → **Valores separados por comas (.csv)**.
+2. Reemplazar `src/lib/Listado_Masters.csv` con el descargado (mismo nombre).
+3. Commit `chore: refresh masters CSV fallback`.
+4. PR y merge.
+
+---
+
+## Migrar datos hardcoded a Google Sheets
+
+Patrón genérico para mover cualquier dataset hardcoded al flujo Sheet → Apps Script → API route. Referencia `app/api/programs/masters/route.ts` como plantilla.
+
+### Paso 1 — Sheet
+
+1. Crear Google Sheet nuevo con una hoja principal.
+2. Fila 1: headers exactos que espera tu parser (ej. `id | categoria | titulo | descripcion | precio | color_borde`). **Sin espacios, sin mayúsculas mixtas inconsistentes**.
+3. Llenar con los datos actuales del TS/JSON.
+
+### Paso 2 — Apps Script
+
+1. En el Sheet: Extensiones → Apps Script.
+2. Reemplazar el contenido con:
+   ```js
+   function doGet(e) {
+     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+     const [headers, ...rows] = sheet.getDataRange().getValues();
+     const data = rows
+       .filter(row => row[0] !== "")  // ignora filas vacías
+       .map(row => Object.fromEntries(headers.map((h, i) => [h, row[i]])));
+     return ContentService
+       .createTextOutput(JSON.stringify(data))
+       .setMimeType(ContentService.MimeType.JSON);
+   }
+   ```
+3. Deploy → New deployment → Web app → Anyone with the link → Deploy.
+4. Copiar URL.
+
+### Paso 3 — API route en Next
+
+Crear `app/api/{recurso}/route.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+
+const APPS_SCRIPT_URL = process.env.RECURSO_APPS_SCRIPT_URL!;
+const CACHE_TTL_MS = 60_000;
+
+let cachedRows: MyItem[] | null = null;
+let cachedAt = 0;
+
+async function getRows(): Promise<MyItem[]> {
+  if (cachedRows && Date.now() - cachedAt < CACHE_TTL_MS) return cachedRows;
+
+  try {
+    const res = await fetch(APPS_SCRIPT_URL, { cache: "no-store" });
+    const data = await res.json();
+    cachedRows = data as MyItem[];
+    cachedAt = Date.now();
+    return cachedRows;
+  } catch (err) {
+    console.error("Apps Script failed, using fallback", err);
+    // opcional: leer CSV local
+    return cachedRows ?? [];
+  }
+}
+
+export async function GET() {
+  const rows = await getRows();
+  return NextResponse.json({ items: rows });
+}
+```
+
+### Paso 4 — Frontend
+
+Cambiar el componente que consume el TS/JSON hardcoded por un fetch al nuevo endpoint:
+
+```tsx
+"use client";
+import { useQuery } from "@tanstack/react-query";
+
+function MyList() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["recurso"],
+    queryFn: () => fetch("/api/recurso").then(r => r.json()),
+  });
+
+  if (isLoading) return <p>Cargando...</p>;
+  return <ul>{data?.items.map(i => <li key={i.id}>{i.titulo}</li>)}</ul>;
+}
+```
+
+### Paso 5 — Cleanup
+
+1. Borra el TS/JSON hardcoded.
+2. Actualiza `docs/DATA.md` para reflejar la nueva fuente.
+3. Agrega una sección en `docs/MANUAL_USUARIO.md` explicando cómo editar el Sheet nuevo (copiando la estructura de la sección de maestrías).
+4. Compartir el Sheet con el staff.
+
+### Qué considerar
+
+- **Rate limits**: Apps Script tiene límite de ejecuciones/día (~20,000 en cuenta gratuita). El caché de 1 min del API route es suficiente para el tráfico actual.
+- **CSV fallback**: opcional pero recomendado para datos críticos. Mantenerlo actualizado manualmente o con un cron que descargue el Sheet.
+- **Validación**: Apps Script no valida tipos — un precio mal escrito como `"tres mil"` llega como string. Agregar `Number(row.precio)` o similar en el API route.
+
+---
+
+## Subir una imagen nueva a S3
+
+Requiere credenciales de AWS para el bucket `images-bucket-landing-page`.
+
+1. Pedir a admin de AWS acceso al bucket (o que te suban la imagen).
+2. Subir archivo al prefijo correspondiente: `public/destinos/`, `public/logos/`, `public/team/`, etc.
+3. Configurar permisos del objeto: `s3:GetObject` público (o usar bucket policy).
+4. URL resultante: `https://images-bucket-landing-page.s3.us-east-2.amazonaws.com/public/{prefijo}/{archivo}.{ext}`.
+5. Usar esa URL en código. Como el dominio está en `next.config.mjs → remotePatterns`, `<Image>` la acepta.
+
+### Si quieres un CDN con caché mejor
+
+Considerar CloudFront encima del bucket (no configurado actualmente). Precio bajo, beneficia carga global.
+
+---
+
+## Deploy de emergencia / rollback
+
+### Rollback a una versión previa
+
+1. En Vercel dashboard → Deployments.
+2. Buscar un deployment previo que esté OK (hay un tag verde "Ready").
+3. Click en el menú `⋯` → **Promote to Production**.
+4. Confirmar. La promoción es instantánea (sin rebuild).
+
+### Revertir un commit en `development`
+
+Si un commit malo ya se mergeó:
+
+```bash
+git checkout development
+git pull
+git revert {sha_del_commit_malo}
+git push
+```
+
+Vercel desplegará automáticamente el revert.
+
+> **No uses `git reset --hard` en `development`** — es shared branch. Usa revert.
+
+### Forzar redeploy sin cambios
+
+Útil si Vercel se "pegó" o una env var se actualizó:
+
+- Vercel dashboard → Deployments → Redeploy último deployment.
+- O: un commit vacío: `git commit --allow-empty -m "chore: redeploy"` y push.

--- a/docs/TUTORIALES.md
+++ b/docs/TUTORIALES.md
@@ -24,6 +24,7 @@ Recetas paso-a-paso para tareas comunes. Las que dicen **(staff)** las puede hac
 - [Rotar el URL del Apps Script de maestrías](#rotar-el-url-del-apps-script-de-maestrías)
 - [Actualizar el CSV fallback de maestrías](#actualizar-el-csv-fallback-de-maestrías)
 - [Migrar datos hardcoded a Google Sheets](#migrar-datos-hardcoded-a-google-sheets)
+- [Ejemplo trabajado: migrar destinos a Sheets (guía para futuros devs)](#ejemplo-trabajado-migrar-destinos-a-sheets-guía-para-futuros-devs)
 - [Subir una imagen nueva a S3](#subir-una-imagen-nueva-a-s3)
 - [Deploy de emergencia / rollback](#deploy-de-emergencia--rollback)
 
@@ -316,6 +317,234 @@ function MyList() {
 - **Rate limits**: Apps Script tiene límite de ejecuciones/día (~20,000 en cuenta gratuita). El caché de 1 min del API route es suficiente para el tráfico actual.
 - **CSV fallback**: opcional pero recomendado para datos críticos. Mantenerlo actualizado manualmente o con un cron que descargue el Sheet.
 - **Validación**: Apps Script no valida tipos — un precio mal escrito como `"tres mil"` llega como string. Agregar `Number(row.precio)` o similar en el API route.
+
+---
+
+## Ejemplo trabajado: migrar destinos a Sheets (guía para futuros devs)
+
+> **Estado**: no implementado aún. Este tutorial describe **cómo se haría** cuando el equipo decida ejecutarlo. Sirve como plantilla para migrar cualquier otro dataset (camps, precios, etc.) — solo cambia nombres.
+
+Migrar **destinos** del archivo TypeScript hardcoded `src/data/destinations.ts` al patrón Sheet. Después de esta migración, el staff podrá editar país, descripción, número de programas, sistema educativo y economía directamente en Google Sheets sin tocar código. Lo único que seguirá requiriendo dev será subir una imagen nueva a S3.
+
+**Tiempo estimado**: 2–3 horas.
+
+### Antes de empezar
+
+- Acceso de edición al Google Workspace de The Gate (para crear el Sheet y publicar el Apps Script).
+- Acceso de write al repo (para crear la API route y modificar el page).
+- Este tutorial abierto en paralelo con `app/api/programs/masters/route.ts` (lo vas a estar copiando y adaptando).
+
+### Paso 1 — Crear el Sheet
+
+1. Crear un nuevo Google Sheet. Si ya existe "TheGate Contenido" con el Sheet de maestrías, **agregar una pestaña nueva** llamada `destinos` en vez de crear un Sheet separado. Así el staff tiene todo en un solo link.
+2. En la fila 1, estos headers en este orden exacto:
+   ```
+   name | programs | flagImage | placeImage | description | educationSystem | economy
+   ```
+3. Copiar los datos actuales desde `src/data/destinations.ts`. Para imágenes, pegar las URLs de S3 tal cual están en el TS (ej. `https://images-bucket-landing-page.s3.us-east-2.amazonaws.com/public/destinos/australia.jpg`).
+4. Dejar la columna `programs` como string (`"45+"`) — el componente la muestra así, no es un número que sume.
+5. Compartir el Sheet con el staff con permiso de edición.
+
+> **Nota sobre `position`**: el campo `position` (coordenadas CSS para los polaroids flotantes del Hero del home) **no se migra al Sheet**. Se queda hardcoded en código, en un archivo separado, para los primeros 6 destinos que aparecen como polaroids. Razón: es un detalle visual que el staff no debería tocar porque romper `position` rompe el layout.
+
+### Paso 2 — Crear el Apps Script
+
+1. En el Sheet: **Extensiones → Apps Script**.
+2. Reemplazar el contenido del editor con:
+   ```js
+   function doGet() {
+     const sheet = SpreadsheetApp
+       .getActiveSpreadsheet()
+       .getSheetByName("destinos");
+     const [headers, ...rows] = sheet.getDataRange().getValues();
+     const data = rows
+       .filter(row => row[0] !== "")
+       .map(row => Object.fromEntries(headers.map((h, i) => [h, row[i]])));
+     return ContentService
+       .createTextOutput(JSON.stringify(data))
+       .setMimeType(ContentService.MimeType.JSON);
+   }
+   ```
+   - `getSheetByName("destinos")` referencia la pestaña por nombre.
+   - `filter(row => row[0] !== "")` ignora filas vacías al final de la hoja.
+3. **Guardar** (Ctrl+S o el ícono de disco).
+4. **Deploy** → **New deployment** → tipo **Web app**:
+   - Execute as: **Me**.
+   - Who has access: **Anyone with the link**.
+   - Deploy.
+5. Copiar la URL resultante (algo como `https://script.google.com/macros/s/AKfycb.../exec`).
+6. Probar la URL en el navegador: debe devolver JSON con los destinos.
+
+### Paso 3 — Agregar env var (opcional pero recomendado)
+
+Si todavía no migraste los endpoints hardcoded a env vars, hazlo ahora para destinos:
+
+1. En `.env.local` (local dev) agrega:
+   ```env
+   DESTINATIONS_APPS_SCRIPT_URL=https://script.google.com/macros/s/AKfycb.../exec
+   ```
+2. En Vercel (Project Settings → Environment Variables) agregar la misma key en **Production** y **Preview** con el mismo valor.
+
+Si decides seguir con hardcoded (peor práctica pero aceptable si quieres ir rápido), usarás la URL directa en el siguiente paso.
+
+### Paso 4 — Crear la API route
+
+Crear el archivo `app/api/destinos/route.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import path from "path";
+
+const APPS_SCRIPT_URL = process.env.DESTINATIONS_APPS_SCRIPT_URL ??
+  "https://script.google.com/macros/s/AKfycb.../exec"; // fallback si env var no está
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min — destinos cambian menos que maestrías
+
+interface Destination {
+  name: string;
+  programs: string;
+  flagImage: string;
+  placeImage: string;
+  description: string;
+  educationSystem: string;
+  economy: string;
+}
+
+let cached: Destination[] | null = null;
+let cachedAt = 0;
+
+async function getDestinations(): Promise<Destination[]> {
+  if (cached && Date.now() - cachedAt < CACHE_TTL_MS) return cached;
+
+  try {
+    const res = await fetch(APPS_SCRIPT_URL, { cache: "no-store" });
+    if (!res.ok) throw new Error(`Apps Script ${res.status}`);
+    const data = (await res.json()) as Destination[];
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error("empty response");
+    }
+    cached = data;
+    cachedAt = Date.now();
+    return cached;
+  } catch (err) {
+    console.error("[destinos API] Apps Script failed, using last cache", err);
+    // Opcional: leer un CSV fallback en src/lib/destinos-fallback.csv
+    return cached ?? [];
+  }
+}
+
+export async function GET() {
+  const items = await getDestinations();
+  return NextResponse.json({ items });
+}
+```
+
+Notar:
+- Caché de **5 minutos** en vez de 1 (maestrías cambian más seguido que destinos).
+- Fallback simplificado: si el Apps Script falla y no hay caché, devuelve array vacío. Se puede mejorar con un CSV fallback como el de maestrías.
+- La URL tiene fallback hardcoded **por seguridad** — si olvidas configurar la env var en Vercel, sigue funcionando.
+
+### Paso 5 — Actualizar el componente consumidor
+
+`/destinos` actualmente lee `src/data/destinations.ts` directamente. Cambiar para que consuma la API:
+
+**Opción A — Server component (más simple, recomendada)**:
+
+```tsx
+// app/destinos/page.tsx
+async function getDestinos() {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/destinos`, { next: { revalidate: 300 } });
+  const { items } = await res.json();
+  return items;
+}
+
+export default async function DestinosPage() {
+  const destinos = await getDestinos();
+  return <Destinations items={destinos} />; // pasar como prop
+}
+```
+
+**Opción B — Client component con React Query** (consistente con maestrías):
+
+```tsx
+"use client";
+import { useQuery } from "@tanstack/react-query";
+
+function DestinosList() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["destinos"],
+    queryFn: () => fetch("/api/destinos").then(r => r.json()),
+    staleTime: 5 * 60 * 1000,
+  });
+  if (isLoading) return <SkeletonGrid />;
+  return <Destinations items={data?.items ?? []} />;
+}
+```
+
+**Recomendación**: Opción A — destinos no necesita refetch en el cliente ni paginación, y rinde mejor en SEO.
+
+### Paso 6 — Polaroids del Hero del home
+
+El Hero del home usa `destinations.filter(d => d.position).slice(0, 6)` para los polaroids flotantes. Como `position` no se migra al Sheet, mantener un archivo separado:
+
+Crear `src/data/destinationsPolaroids.ts`:
+
+```ts
+// Solo datos visuales de los polaroids — no incluir aquí datos editables como descripción.
+// El `name` debe coincidir con el nombre en el Sheet para hacer lookup.
+export const polaroidPositions: Record<string, CSSProperties> = {
+  "Canadá":        { top: "18%", left: "4%" },
+  "Reino Unido":   { top: "10%", right: "4%" },
+  "Australia":     { top: "52%", left: "2%" },
+  "Francia":       { top: "42%", left: "14%" },
+  "Estados Unidos": { top: "28%", right: "3%" },
+  "Alemania":      { top: "60%", right: "3%" },
+};
+```
+
+Y en `src/components/Hero/Hero.tsx`, modificar `floatingCards` para combinar:
+
+```tsx
+import { polaroidPositions } from "@src/data/destinationsPolaroids";
+
+// En vez de importar destinations directo, recibir como prop o fetchear
+const floatingCards = destinations
+  .filter(d => polaroidPositions[d.name])
+  .map(d => ({ ...d, position: polaroidPositions[d.name] }))
+  .slice(0, 6);
+```
+
+> Esto hace el Hero del home un client component que fetchea destinos, o pasa los datos como props desde `app/page.tsx`.
+
+### Paso 7 — Cleanup
+
+1. **Borra** `src/data/destinations.ts` (si ya no lo consume nada más — verifica con `grep -r "destinations" src/ app/`).
+2. **Actualiza `docs/DATA.md`**: mueve "Destinos" de la sección "Candidatos para migrar a Sheets" a una sección nueva llamada "Destinos (Google Sheet + Apps Script)" con el mismo formato de la sección de maestrías.
+3. **Actualiza `docs/MANUAL_USUARIO.md`**: agrega una sección "Editar destinos" con los headers y reglas del Sheet.
+4. **Commit** en una rama `feat/migrate-destinations-to-sheets`.
+
+### Paso 8 — Testing en preview
+
+1. PR contra `development` → Vercel genera un preview.
+2. En el preview:
+   - Abrir `/destinos` y verificar que todos los países cargan con fotos y textos correctos.
+   - Editar una descripción en el Sheet → esperar 5 min → refresh preview → verificar cambio.
+   - Forzar un error (cambiar temporalmente `APPS_SCRIPT_URL` a basura en la env var de preview) → verificar que el fallback devuelve caché o array vacío sin crashear.
+3. Si todo OK, mergear a `development`.
+
+### Replicar para otros datasets
+
+Esta misma receta sirve para **camps**, **precios de `/estudiante`**, **logos de aliados**, etc. Solo cambian:
+
+- Nombre de la pestaña en el Sheet.
+- Headers de las columnas.
+- Shape del type TypeScript.
+- Ruta de la API route (`/api/camps`, `/api/precios`, etc.).
+- Componente que consume los datos.
+
+Lo demás (estructura del Apps Script, patrón de caché, fallback, env var) es idéntico.
 
 ---
 


### PR DESCRIPTION
## Summary
Agrega una carpeta `/docs` con 7 archivos cubriendo:

- **Staff no técnico**: cómo editar el Google Sheet de maestrías, pedir cambios, verificar el sitio tras un deploy.
- **Developers**: stack, estructura, setup, deploy, paleta, componentes, rutas, fuentes de datos, convenciones de git.
- **Recetas paso a paso**: editar el Sheet, agregar un destino, cambiar un precio, migrar datos hardcoded a Sheets (patrón genérico), mover endpoints a env vars, rollback en Vercel.

## Archivos

| Archivo | Audiencia | Qué cubre |
|---------|-----------|-----------|
| `docs/README.md` | Todos | Índice y mapa de audiencia |
| `docs/MANUAL_USUARIO.md` | Staff | Edición del Sheet, cómo pedir cambios, checklist post-deploy |
| `docs/ARQUITECTURA.md` | Dev | Stack, carpetas, npm, env, Vercel, git, paleta |
| `docs/PAGINAS.md` | Dev | Cada ruta: qué hace, qué data, qué componentes |
| `docs/DATA.md` | Dev | Todas las fuentes + candidatos para migrar a Sheets |
| `docs/COMPONENTES.md` | Dev | Componentes reutilizables con props |
| `docs/TUTORIALES.md` | Staff + Dev | Recetas paso a paso |

## Énfasis en "editable vía Sheets"
Siguiendo el pedido: el patrón de Google Sheets que hoy usa maestrías queda documentado + se identifican **7 datasets candidatos** para replicarlo (licenciaturas, camps, precios de servicios, destinos, logos aliados, textos de categorías, equipo), priorizados por impacto. `docs/TUTORIALES.md` incluye la receta genérica para migrar cualquier dataset hardcoded al patrón Sheet → Apps Script → API route.

## Test plan
- [ ] Leer `docs/README.md` y confirmar que los links a los otros archivos funcionan.
- [ ] Compartir `docs/MANUAL_USUARIO.md` con una persona de staff y validar que entiende cómo editar el Sheet sin preguntas técnicas.
- [ ] Un developer nuevo lee `docs/ARQUITECTURA.md` y logra correr el sitio localmente (`npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)